### PR TITLE
Fix bug that return `user.password` on `email` field when create a user

### DIFF
--- a/packages/server/src/modules/user/UserType.ts
+++ b/packages/server/src/modules/user/UserType.ts
@@ -17,7 +17,7 @@ export const UserType = new GraphQLObjectType<User>({
     },
     email: {
       type: new GraphQLNonNull(GraphQLString),
-      resolve: user => user.password,
+      resolve: user => user.email,
     },
     password: {
       type: new GraphQLNonNull(GraphQLString),

--- a/packages/server/src/modules/user/mutations/userRegisterMutation.ts
+++ b/packages/server/src/modules/user/mutations/userRegisterMutation.ts
@@ -8,7 +8,7 @@ export const userRegisterMutation = mutationWithClientMutationId({
   name: 'UserRegister',
   inputFields: {
     username: { type: new GraphQLNonNull(GraphQLString) },
-    name: { type: new GraphQLNonNull(GraphQLString) },
+    displayName: { type: new GraphQLNonNull(GraphQLString) },
     email: { type: new GraphQLNonNull(GraphQLString) },
     password: { type: new GraphQLNonNull(GraphQLString) },
   },


### PR DESCRIPTION
## Description

This PR fixes a bug that return `user.password` instead of `user.email` on `email` field when run a mutation (or query) that return `type User`.